### PR TITLE
Adding some missing imports

### DIFF
--- a/streaming_meter.py
+++ b/streaming_meter.py
@@ -25,6 +25,7 @@ import logging
 from configparser import ConfigParser, NoOptionError
 from requests.exceptions import ConnectionError
 from pyradio import StationInfo, StreamPlayer
+from pygame.locals import QUIT, KEYUP, K_ESCAPE
 
 
 # ToDo: Add logging


### PR DESCRIPTION
originally was using from pygame.locals import *
Didn't like import * so I removed it and now QUIT, KEYUP, K_ESCAPE are unknown.